### PR TITLE
node-fetch at version 2.2+ doesnt have getAll. fix bug

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,4 +1,4 @@
-const map = new WeakMap()
+const map = new WeakMap();
 const wm = o => map.get(o)
 const fetch = require('node-fetch')
 const fs = require('fs-extra')
@@ -127,10 +127,11 @@ module.exports = class Cache {
     if (res.status === 206)
       throw new TypeError('Partial response (status code 206) is unsupported')
 
-    let varyHeaders = res.headers.getAll('Vary')
+    const varyHeaders = res.headers.get('Vary');
 
-    if (varyHeaders.includes('*'))
-      throw new TypeError('Vary header contains *')
+    if (varyHeaders && varyHeaders.indexOf('*') > -1) {
+        throw new TypeError('Vary header contains *')
+    }
 
     if (res.body != null)
       if (res.bodyUsed)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "dependencies": {
-    "fs-extra": "^1.0.0"
+    "fs-extra": "^1.0.0",
+    "node-fetch": "^2.3.0"
   },
   "devDependencies": {
     "codecov": "^1.0.1",


### PR DESCRIPTION
Fix issues with get all deprecated method in fetch node 